### PR TITLE
Remove dotnet-format

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,48 +1,19 @@
 {
   "tasks": [
     {
-      "name": "dotnet-format-whitespace",
-      "group": "pre-commit",
-      "command": "dotnet",
-      "args": [
-        "format",
-        "whitespace",
-        "--include",
-        "${staged}"
-      ],
-      "include": [
-        "**/*.cs",
-        "**/*.csproj"
-      ]
-    },
-    {
-      "name": "dotnet-format-style",
-      "group": "pre-commit",
-      "command": "dotnet",
-      "args": [
-        "format",
-        "style",
-        "--include",
-        "${staged}"
-      ],
-      "include": [
-        "**/*.cs",
-        "**/*.csproj"
-      ]
-    },
-    {
       "name": "jb-cleanupcode",
       "group": "pre-commit",
       "command": "pwsh",
       "args": [
         "-Command",
         "$Joined = \"",
-        "${staged}",
+        "${all-files}",
         "\".Trim() -replace(' ', ';');",
         "dotnet jb cleanupcode Couple.sln --include=$Joined;"
       ],
       "include": [
-        "**/*.razor.cs",
+        "**/*.csproj",
+        "**/*.cs",
         "**/*.razor",
         "**/*.html",
         "**/*.css",

--- a/Api/Infrastructure/HttpRequestDataExtensions.cs
+++ b/Api/Infrastructure/HttpRequestDataExtensions.cs
@@ -35,10 +35,7 @@ public static class HttpRequestDataExtensions
         {
             return new()
             {
-                Value = requestObject,
-                Json = requestBody,
-                IsValid = false,
-                Errors = validationResult.Errors
+                Value = requestObject, Json = requestBody, IsValid = false, Errors = validationResult.Errors
             };
         }
 

--- a/Client/Model/Image/ImageModel.cs
+++ b/Client/Model/Image/ImageModel.cs
@@ -4,6 +4,8 @@ namespace Couple.Client.Model.Image;
 
 public class ImageModel : IDone, IReadOnlyImageModel
 {
+    private DateTime _takenOn;
+
     public ImageModel(DateTime takenOn, byte[] data, bool isFavourite)
     {
         TakenOn = takenOn;
@@ -19,8 +21,6 @@ public class ImageModel : IDone, IReadOnlyImageModel
     private ImageModel(Guid id, DateTime takenOn, byte[] data, bool isFavourite, int order) : this(id, takenOn, data,
         isFavourite) => Order = order;
 #pragma warning restore IDE0051
-
-    private DateTime _takenOn;
 
     public DateOnly TakenOnDate { get; private set; }
 

--- a/Messaging/Infrastructure/HttpRequestExtensions.cs
+++ b/Messaging/Infrastructure/HttpRequestExtensions.cs
@@ -35,10 +35,7 @@ public static class HttpRequestExtensions
         {
             return new()
             {
-                Value = requestObject,
-                Json = requestBody,
-                IsValid = false,
-                Errors = validationResult.Errors
+                Value = requestObject, Json = requestBody, IsValid = false, Errors = validationResult.Errors
             };
         }
 


### PR DESCRIPTION
## EditorConfig

### Integration with IDEs

`.editorconfig`, as the name suggests, stores the list of configurations that is used by editors (or IDEs) to enforce consistent coding styles for everyone that works in the codebase. These settings in EditorConfig take precedence over IDEs settings, which affects: 

1. What the IDE flags out as `suggestion`, `warning` and `error`.
2. How the IDE's auto-formatter formats the code.

This would be absolutely amazing, but the IDEs do not necessarily honour all the settings. It seems that Visual Studio honours more settings than Rider. For example, the setting `dotnet_naming_rule.public_fields_should_be_pascalcase.severity = error`, Visual Studio would correctly reflect an error, but not Rider.

### Integration with Code Formatters

There are 2 popular code formatters that can be added into our project without introducing 3rd party dependencies in the form of additional NuGET packages (as these are `tools` which are executed by calling `dotnet {toolName}`):

1. [dotnet-format](https://github.com/dotnet/format)
2. [CleanupCode](https://www.jetbrains.com/help/rider/CleanupCode.html)

While both tools work, both tools have their pros & cons. `dotnet-format` runs faster; `CleanupCode` has a long startup time of a few seconds; formatting even a single file would take a few seconds. `CleanupCode` is able to perform additional functionalities such as cleaning up unused imports properly, removing unnecessary code and adhering to line limits.
 
Also, some nits do not seem to have to a corresponding setting in `.editorconfig` e.g. `new T() {}`, where `()` is not required, and some of the settings are not honoured by the Code Formatters.

### Other Thoughts

1. There are many settings (perhaps > 500) and specifying each setting in `.editorconfig` would result in a really bloated file ([example](https://github.com/meziantou/CsharpProjectTemplate/blob/main/.editorconfig)), making it hard to understand. I have simplified the file by removing settings with default values that match our codebase, and removing severity settings. Most of the settings specified are settings that do not have default values, which I personally found it odd since these settings are pretty standard and should have default values as well. Ideally, .NET creates a model `.editorconfig` file which we could reference from, but as of today, no such file exists.

## Automated running of Code Formatter

The tools mentioned above allow us to manually format code. However, developers are frequently forgetful, and running the above tools in a `pre-commit` hook would ensure that any committed code has been formatted. There are 2 options:

1. Write the `pre-commit` hook to run the Code Formatter
2. Use [Husky.NET](https://github.com/alirezanet/husky.net)

Option 1, implemented in the naive manner, would not include changes made by the Code Formatter in the same commit; the developer has to identify the changes and run a `git amend` add these changes to the previous commit. While this could be circumvented by updating the `pre-commit` hook to run `git add .`, this causes the side-effect of adding all changes into the commit; there would be occasions where the developer is performing a partial commit (only some changes made in a file are staged), a full commit is performed instead.

Option 2 solves the issues mentioned earlier, so let's use this option.
